### PR TITLE
Resolves #18

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,4 +138,11 @@ mod tests {
             "Decrypted message is not the same with the original message"
         );
     }
+
+    #[test]
+    fn reps() {
+        for _ in 0..10 {
+            test_single_key_delay_encryption();
+        }
+    }
 }


### PR DESCRIPTION
# ChangeLog
- `delay_encryption::encrypt()` now takes message as `&str`.
![image](https://github.com/user-attachments/assets/21765a51-f5f6-4cff-81b0-055825c66c11)

- `delay_encryption::decrypt()` returns the original message string.
![image](https://github.com/user-attachments/assets/69c7c7b0-297e-47fc-a20c-f20abf0386c1)

These changes will be valid until the returning type of `decrypt()` generalizes to any `T: AsRef<[u8]>`.